### PR TITLE
Remove charToInteger

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,14 +235,9 @@ You can install the module as following command.
 
 | from              |    to          |   function                         |
 |:-----------------:|:--------------:|:----------------------------------:|
-| charactor         | Integer        | charToInteger(chara)               |
 | Byte              | 16進表現String | toHexString(byte)                  |
 | 16進表現String    |  Integer[]     | toHexArray(str)                    |
 
-
-* 1バイト文字をHEX数値にしたい
-
-    EL.charToInteger = function( chara )
 
 * 1バイトを文字列の16進表現へ（1Byteは必ず2文字にする）
 
@@ -377,4 +372,3 @@ seoj, deoj, esv, epcは文字列でもOK，edtは数値も文字列もOKにし�
 0.0.11 マニュアルの英語表記追加
 
 0.0.10 API追加とBug修正，PropertyMap対応，sendOPC1のEPCを3バイトにしたので0.0.9と互換性きえた．Node.jsからだと家電の速度が間に合わないのでUDPの取りこぼしが発生する．ライブラリとしては対処しないこととなった．．
-

--- a/index.js
+++ b/index.js
@@ -270,43 +270,6 @@ EL.ELDATA2Array = function( eldata ) {
 	return ret;
 };
 
-
-// 1バイト文字をHEX数値にしたい，基本機能であるかもしれない．
-EL.charToInteger = function( chara ) {
-	var ret = 0;
-	switch (chara) {
-	  case "0": case "1": case "2": case "3": case "4": case "5": case "6": case "7": case "8": case "9":
-		ret = parseInt(chara);
-		break;
-	  case "a": case "A":
-		ret = 10;
-		break;
-
-	  case "b": case "B":
-		ret = 11;
-		break;
-
-	  case "c": case "C":
-		ret = 12;
-		break;
-
-	  case "d": case "D":
-		ret = 13;
-		break;
-
-	  case "e": case "E":
-		ret = 14;
-		break;
-
-	  case "f": case "F":
-		ret = 15;
-		break;
-
-	  default : ret = 0; break;
-	}
-	return ret;
-}
-
 // 1バイトを文字列の16進表現へ（1Byteは必ず2文字にする）
 EL.toHexString = function( byte ) {
 	// 文字列0をつなげて，後ろから2文字分スライスする
@@ -323,7 +286,7 @@ EL.toHexArray = function( string ) {
 		l = string.substr( i, 1 );
 		r = string.substr( i+1, 1 );
 
-		ret.push( (EL.charToInteger(l) * 16) + EL.charToInteger(r) );
+		ret.push( (parseInt(l, 16) * 16) + parseInt(r, 16) );
 	}
 
 	return ret;


### PR DESCRIPTION
charToIntegerで文字から16進数に変換する部分はJavaScriptの標準関数, parseIntに第2引数を与えることで同様の処理が行えるため、そちらに変更しました。
以前の実装と挙動はほとんど同じですが、一部例外として、範囲外の文字が現れた場合、NaNが返るようになっています。
