### PR TITLE
Support IPv6 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ You can install the module as following command.
 
 ### 初期化，バインド, initialize
 
-    EL.initialize = function ( objList, userfunc )
+    EL.initialize = function ( objList, userfunc, ipVer )
 
 
 ### データ表示系, data representations
@@ -377,4 +377,3 @@ seoj, deoj, esv, epcは文字列でもOK，edtは数値も文字列もOKにし�
 0.0.11 マニュアルの英語表記追加
 
 0.0.10 API追加とBug修正，PropertyMap対応，sendOPC1のEPCを3バイトにしたので0.0.9と互換性きえた．Node.jsからだと家電の速度が間に合わないのでUDPの取りこぼしが発生する．ライブラリとしては対処しないこととなった．．
-


### PR DESCRIPTION
IPv6対応させてみました。
変更点としては、initializeに対して第3引数としてIPプロトコルバージョンを指定する項目を追加しています。
第三引数にIPのバージョン、例えばIPv6を利用する場合、6を与えることでIPv6にて通信を行うことが可能となっています。
未指定の場合、もしくは6以外が与えられた場合は、IPv4にて今まで通りの動作をするようにしています。
なので、これまでにechonet-lite.jsを用いて作成されたアプリケーションに対する互換性はしっかりと残してあります。
