### PR TITLE
16以上のプロパティマップの受信後の自動プロパティ取得が正しく動作していない不具合を修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,16 +319,6 @@ EL.parseDetail = function( opc, str ) {
 		let now = 0;  // 入力データの現在処理位置, Index
 		let edt = [];  // 各edtをここに集めて，retに集約
 
-		// property mapだけEDT[0] != バイト数なので別処理
-		if( epc == 0x9d || epc == 0x9e || epc == 0x9f ) {
-			if( pdc >= 17) { // プロパティの数が16以上の場合（プロパティカウンタ含めてPDC17以上）は format 2
-				// 0byte=epc, 2byte=pdc, 4byte=edt
-				ret[ EL.toHexString(epc) ] = EL.bytesToString( EL.parseMapForm2( str.substr(4) ) );
-				return ret;
-			}
-			// format 2でなければ以下と同じ形式で解析可能
-		}
-
 		// それ以外はEDT[0] == byte数
 		// OPCループ
 		for (let i = 0; i < opc; i += 1) {


### PR DESCRIPTION
2回、format 2のデコードを行ってしまって、「Get プロパティマップ」("9f")の受信後の自動プロパティ取得で、違うプロパティを要求していた。
原因は、次の2か所で format 2 形式のプロパティマップの変換を行っているため。
(1)バイトデータからELDATA形式に変換する処理(EL.parseBytes)で、format 2形式のプロパティマップデータを format 1 相当の形式に変換している
(2)「Get プロパティマップ」("9f")の受信時にels.DETAILs["9f"]に対して、format 2形式のプロパティマップを format 1 相当の形式に変換している

(2)のほうの処理をやめるほうが影響が少ないが、それだと EL.initialize のコールバック時点で els が仕様外の形式になってしまうので、(1)のELDATA形式への変換時の「format 1相当の形式への変換」をやめてしまう。

(追記)
修正前は、MoekadenRoomの「低圧スマート電力量メータ」のプロパティがちゃんと取れていないようでしたが、本修正で直ってそうでした。
修正方法は(1)と(2)でどちらが良いか迷いましたが、EL.Initializeのコールバック時でもECHONET Liteの仕様の形式になっていたほうが良い判断し、(2)の処理を消しています。
修正箇所がいまいちなら、却下していい感じに修正してもらえたらと思います。(不具合原因はたぶん正しいと思うのですが)
