### PR TITLE
EL.SearchをEL.Initializeを完了する前に呼んでしまい情報取得がスタックしてしまう場合があることを解消

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,10 +86,10 @@ let EL = {
 // Nodejsの対応が遅れていてまだうまく動かないみたい，しばらくipVer = 4でやる。
 // 複数NICがあるときにNICを指定できるようにした。NICの設定はmulticastAddrに出力したいインタフェースのIPを指定する。
 // ipVer == 0の時はsocketが4と6の2個手に入れることに注意
-EL.initialize = async function (objList, userfunc, ipVer = 4, Options = {v4: '', v6: '', ignoreMe: true, autoGetProperties: true, autoGetDelay: 1000, debugMode: false}) {
+EL.initialize = function (objList, userfunc, ipVer = 4, Options = {v4: '', v6: '', ignoreMe: true, autoGetProperties: true, autoGetDelay: 1000, debugMode: false}) {
 
 	EL.debugMode = Options.debugMode; // true: show debug log
-	await EL.renewNICList();	// Network Interface Card List
+	EL.renewNICList();	// Network Interface Card List
 	EL.ipVer = ipVer;	// ip version
 
 	EL.sock4 = null;
@@ -226,11 +226,11 @@ EL.release = function () {
 
 // NICリスト更新
 // loopback無視
-EL.renewNICList = async function () {
+EL.renewNICList = function () {
 	EL.nicList.v4 = [];
 	EL.nicList.v6 = [];
-	let interfaces = await os.networkInterfaces();
-	interfaces = await EL.objectSort(interfaces);  // dev nameでsortすると仮想LAN候補を後ろに逃がせる（とみた）
+	let interfaces = os.networkInterfaces();
+	interfaces = EL.objectSort(interfaces);  // dev nameでsortすると仮想LAN候補を後ろに逃がせる（とみた）
 	// console.log('EL.renewNICList(): interfaces:', interfaces);
 
 	let macArray = [];
@@ -242,27 +242,27 @@ EL.renewNICList = async function () {
 				switch(details.family) {
 					case 4:   // win
 					case "IPv4":  // mac
-					// await console.log( 'EL.renewNICList(): IPv4 details:', details );
+					// console.log( 'EL.renewNICList(): IPv4 details:', details );
 					EL.nicList.v4.push({name:name, address:details.address});
-					macArray = await EL.toHexArray( details.mac.replace(/:/g, '') ); // ここで見つけたmacを機器固有番号に転用
+					macArray = EL.toHexArray( details.mac.replace(/:/g, '') ); // ここで見つけたmacを機器固有番号に転用
 					break;
 
 					case 6:  // win
 					case "IPv6":  // mac
-					// await console.log( 'EL.renewNICList(): IPv6 details:', details );
+					// console.log( 'EL.renewNICList(): IPv6 details:', details );
 					EL.nicList.v6.push({name:name, address:details.address});
-					macArray = await EL.toHexArray( details.mac.replace(/:/g, '') ); // ここで見つけたmacを機器固有番号に転用
+					macArray = EL.toHexArray( details.mac.replace(/:/g, '') ); // ここで見つけたmacを機器固有番号に転用
 					break;
 
 					default:
-					await console.log( 'EL.renewNICList(): no assoc default:', details );
+					console.log( 'EL.renewNICList(): no assoc default:', details );
 					break;
 				}
 			}
 		}
-		// await console.log( 'EL.renewNICList(): nicList:', EL.nicList );
+		// console.log( 'EL.renewNICList(): nicList:', EL.nicList );
 	}
-	// await console.log( 'EL.renewNICList(): nicList:', EL.nicList );
+	// console.log( 'EL.renewNICList(): nicList:', EL.nicList );
 
 	// macアドレスを識別番号に転用，localhost, lo0はmacを持たないので使えないから排除
 	// console.log('EL.renewNICList(): interfaces:', interfaces);
@@ -270,7 +270,7 @@ EL.renewNICList = async function () {
 
 	EL.Node_details["83"] = [0xfe, 0x00, 0x00, 0x77, 0x00, 0x00, 0x02, macArray[0], macArray[1], macArray[2], macArray[3], macArray[4], macArray[5], 0x00, 0x00, 0x00, 0x01]; // identifier
 
-	// await console.log( 'EL.renewNICList(): nicList:', EL.nicList );
+	// console.log( 'EL.renewNICList(): nicList:', EL.nicList );
 	return EL.nicList;
 };
 


### PR DESCRIPTION
システム間で移行をしているときに、IF重複指定のバグが顕在化して、バージョンを上げてしまったことにより、情報取得ができない場合があることに気が付きました。
IF重複指定のバグのホットフィックスをそれぞれ入れながら比較検討していくと、
Ver 2.7.0 -> 2.7.1 (最新版でも同様)の段階からうまくいかなくなることがわかりました。

そこで、相違点につき検討しましたところ、EL.initializeをasyncにしなければ問題は解消することがわかりました。

JSの能力が低いので、細かい原因まではさぐれていませんが、EL.initializeが終わってないのにsearchを呼んでしまうあたりに問題があるのかもしれません。1秒ほどsleepしてからEL.searchを呼べば問題がなくなります。

パケットキャプチャレベルでは、2.7.1以降だと、最初にUDPパケットが飛んだあと、無風になります。
```
01:48:17.211766 IP6 fe80::1986:6058:c5d1:f0be.57007 > ff02::1.echonet: UDP, length 18
```
2.7.0以前だと、UDPパケットが2つ飛んで無事情報が返ってきます。
```
01:49:12.472787 IP6 fe80::f7da:dc4b:8188:3624.49747 > ff02::1.echonet: UDP, length 18
01:49:12.472852 IP6 fe80::f7da:dc4b:8188:3624.51612 > ff02::1.echonet: UDP, length 14
```
パケットレベルでも、現に送れてないような感じが見て取れます。

公式で公開されているデモがそのままだとうまくいかないのでこれを修正して頂いてこのプルリクを蹴っていただくか、
同期でも非同期でも結局初期化のコストは変わらないので、同期でやったほうが安全に思いますのでマージいただくかでご検討いただければ幸いです。


