### PR TITLE
非Echonetliteパケットを無視するように修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -1416,7 +1416,7 @@ EL.returner = function (bytes, rinfo, userfunc) {
 		}
 
 		// 機器オブジェクトに関してはユーザー関数に任す
-		userfunc(rinfo, els);
+		userfunc(rinfo, els, null);
 	} catch (e) {
 		userfunc(rinfo, els, e);
 	}

--- a/index.js
+++ b/index.js
@@ -476,6 +476,15 @@ EL.parseBytes = function (bytes) {
 			return null;
 		}
 
+		// ECHONET Liteヘッダ検証（EHD1とEHD2）
+		// 有効な値: 0x1081（規定電文形式）または 0x1082（任意電文形式）
+		// ヘッダが異なる場合はECHONET Liteパケットではないため無視
+		if (bytes[0] !== 0x10 || (bytes[1] !== 0x81 && bytes[1] !== 0x82)) {
+			EL.debugMode ? console.log("EL.parseBytes: Not an ECHONET Lite packet (invalid header). EHD: " +
+				EL.toHexString(bytes[0]) + EL.toHexString(bytes[1])) : 0;
+			return null;
+		}
+
 		// 数値だったら文字列にして
 		let str = "";
 		if (bytes[0] != 'string') {


### PR DESCRIPTION
`EL.parseBytes:  <Buffer 01 00 ff ff 06 06 24 78 23 0b 99 5c 88 88 00 ff 00 ff 09 83 05 ff 01 0e f0 01 d6 62>`

でクラッシュしていたため修正とエラーハンドリングの強化を行った。

また、引数の数が固定となるように修正。